### PR TITLE
Add translations for the Add Extension modal

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -7,6 +7,12 @@ core:
   # Translations in this namespace are used by the admin interface.
   admin:
 
+    # These translations are used in the placeholder Add Extension modal dialog.
+    add_extension:
+      developer_text: "If you're a developer, you can <a>read the docs</a> and have a go at building your own extensions."
+      install_text: "In the meantime, you can look for extensions at the <a>Flarum Community site</a> and install them manually using Composer."
+      temporary_text: "One day in the not-too-distant future, this dialog will allow you to add an extension to your forum with ease. We're building an ecosystem as we speak!"
+
     # These translations are used in the Appearance page.
     appearance:
       colored_header_label: Colored Header


### PR DESCRIPTION
- Adds three translations for this placeholder dialog.
- Updates the instructions to mention Composer.
- Supports https://github.com/flarum/core/pull/752.