### PR TITLE
Admin SMTP UI Translations

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -69,19 +69,6 @@ core:
       submit_button: => core.ref.save_changes
       title: Create Group
 
-    # These translations are used in the SMTP page.
-    smtp:
-      heading: SMTP
-      text: Configure your SMTP settings
-      driver_label: SMTP Driver
-      host_label: "SMTP Host (Url)"
-      from_label: "SMTP From (Email)"
-      port_label: SMTP Port
-      username_label: SMTP Email Username
-      password_label: SMTP Email Password
-      encryption_label: SMTP Encryption
-      submit_button: => core.ref.save_changes
-
     # These translations are used in the Extensions page.
     extensions:
       add_button: Add Extension
@@ -111,7 +98,7 @@ core:
       permissions_button: Permissions
       permissions_text: Configure who can see and do what.
       smtp_button: SMTP
-      smtp_text: Configure your SMTP settings
+      smtp_text: Configure your SMTP settings.
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:
@@ -147,6 +134,20 @@ core:
     # These translations are used in the Settings modal dialog.
     settings:
       submit_button: => core.ref.save_changes
+
+    # These translations are used in the SMTP page.
+    smtp:
+      heading: SMTP
+      text: Configure the SMTP settings your server will use when sending notifications by email
+      driver_label: SMTP Driver
+      host_label: "SMTP Host (URL)"
+      from_label: "SMTP From (Email)"
+      port_label: SMTP Port
+      username_label: SMTP Username
+      password_label: SMTP Password
+      encryption_label: SMTP Encryption
+      submit_button: => core.ref.save_changes
+
 
   # Translations in this namespace are used by the forum user interface.
   forum:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -69,7 +69,7 @@ core:
       submit_button: => core.ref.save_changes
       title: Create Group
 
-    # These translations are used in the SMTP page of the admin interface.
+    # These translations are used in the email page of the admin interface.
     email:
       heading: => core.ref.email
       text: Configure the SMTP settings and addresses your forum will use to send email.

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -85,7 +85,6 @@ core:
       text: Configure the SMTP settings and addresses your forum will use to send email.
       username_label: Username
 
-
     # These translations are used in the Extensions page.
     extensions:
       add_button: Add Extension
@@ -116,7 +115,6 @@ core:
       extensions_text: Add extra functionality to your forum and make it your own.
       permissions_button: Permissions
       permissions_text: Configure who can see and do what.
-
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -69,6 +69,22 @@ core:
       submit_button: => core.ref.save_changes
       title: Create Group
 
+    # These translations are used in the SMTP page of the admin interface.
+    email:
+      heading: => core.ref.email
+      text: Configure the SMTP settings and addresses your forum will use to send email.
+      server_heading: SMTP Server
+      driver_label: Driver
+      host_label: Host
+      port_label: Port
+      encryption_label: Encryption
+      account_heading: SMTP Account
+      username_label: Username
+      password_label: Password
+      adresses_heading: Adresses
+      from_label: Sender
+      submit_button: => core.ref.save_changes
+
     # These translations are used in the Extensions page.
     extensions:
       add_button: Add Extension
@@ -97,8 +113,8 @@ core:
       extensions_text: Add extra functionality to your forum and make it your own.
       permissions_button: Permissions
       permissions_text: Configure who can see and do what.
-      smtp_button: SMTP
-      smtp_text: Configure your SMTP settings.
+      email_button: => core.ref.email
+      email_text: Configure your forum's email settings.
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:
@@ -134,20 +150,6 @@ core:
     # These translations are used in the Settings modal dialog.
     settings:
       submit_button: => core.ref.save_changes
-
-    # These translations are used in the SMTP page.
-    smtp:
-      heading: SMTP
-      text: Configure the SMTP settings your server will use when sending notifications by email
-      driver_label: SMTP Driver
-      host_label: "SMTP Host (URL)"
-      from_label: "SMTP From (Email)"
-      port_label: SMTP Port
-      username_label: SMTP Username
-      password_label: SMTP Password
-      encryption_label: SMTP Encryption
-      submit_button: => core.ref.save_changes
-
 
   # Translations in this namespace are used by the forum user interface.
   forum:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -71,19 +71,20 @@ core:
 
     # These translations are used in the email page of the admin interface.
     email:
-      heading: => core.ref.email
-      text: Configure the SMTP settings and addresses your forum will use to send email.
-      server_heading: SMTP Server
-      driver_label: Driver
-      host_label: Host
-      port_label: Port
-      encryption_label: Encryption
       account_heading: SMTP Account
-      username_label: Username
-      password_label: Password
       adresses_heading: Adresses
+      driver_label: Driver
+      encryption_label: Encryption
       from_label: Sender
+      heading: => core.ref.email
+      host_label: Host
+      password_label: Password
+      port_label: Port
+      server_heading: SMTP Server
       submit_button: => core.ref.save_changes
+      text: Configure the SMTP settings and addresses your forum will use to send email.
+      username_label: Username
+
 
     # These translations are used in the Extensions page.
     extensions:
@@ -109,12 +110,13 @@ core:
       basics_text: "Set your forum title, language, and other basic settings."
       dashboard_button: Dashboard
       dashboard_text: Your forum at a glance.
+      email_button: => core.ref.email
+      email_text: "Configure your forum's email settings."
       extensions_button: Extensions
       extensions_text: Add extra functionality to your forum and make it your own.
       permissions_button: Permissions
       permissions_text: Configure who can see and do what.
-      email_button: => core.ref.email
-      email_text: Configure your forum's email settings.
+
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -69,6 +69,19 @@ core:
       submit_button: => core.ref.save_changes
       title: Create Group
 
+    # These translations are used in the SMTP page.
+    smtp:
+      heading: SMTP
+      text: Configure your SMTP settings
+      driver_label: SMTP Driver
+      host_label: "SMTP Host (Url)"
+      from_label: "SMTP From (Email)"
+      port_label: SMTP Port
+      username_label: SMTP Email Username
+      password_label: SMTP Email Password
+      encryption_label: SMTP Encryption
+      submit_button: => core.ref.save_changes
+
     # These translations are used in the Extensions page.
     extensions:
       add_button: Add Extension
@@ -97,6 +110,8 @@ core:
       extensions_text: Add extra functionality to your forum and make it your own.
       permissions_button: Permissions
       permissions_text: Configure who can see and do what.
+      smtp_button: SMTP
+      smtp_text: Configure your SMTP settings
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -72,7 +72,7 @@ core:
     # These translations are used in the email page of the admin interface.
     email:
       account_heading: SMTP Account
-      adresses_heading: Adresses
+      addresses_heading: Addresses
       driver_label: Driver
       encryption_label: Encryption
       from_label: Sender


### PR DESCRIPTION
This are the translations for flarum/core#933 (or https://github.com/flarum/core/commit/dd0dc44dd833460862272eb4d63b84e0763b2722)

Added:
```yml
# These translations are used in the email page of the admin interface.
email:
    heading: => core.ref.email
    text: Configure the SMTP settings and addresses your forum will use to send email.
    server_heading: SMTP Server
    driver_label: Driver
    host_label: Host
    port_label: Port
    encryption_label: Encryption
    account_heading: SMTP Account
    username_label: Username
    password_label: Password
    adresses_heading: Adresses
    from_label: Sender
    submit_button: => core.ref.save_changes
```
and this (on `core.admin.nav`)
```yml
email_button: => core.ref.email
email_text: Configure your forum's email settings.
```