### PR TITLE
Add translations for API error messages

### DIFF
--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -84,6 +84,13 @@ flarum-tags:
       removed_tags_text: "{username} removed the {tagsRemoved}."
       tags_text: "{tags} tag|{tags} tags"
 
+  # Translations in this namespace are used in messages output by the API.
+  api:
+
+    # These translations are used in messages regarding the number of tags assigned to a discussion.
+    primary_tag_count_text: number of primary tags
+    secondary_tag_count_text: number of secondary tags
+
   # Translations in this namespace are used by the forum and admin interfaces.
   lib:
 


### PR DESCRIPTION
- Adds `:attribute` values for use in `validation.between.numeric`.
- Partially solves flarum/core#973.
- Lines 118 and 134 of [this file](https://github.com/flarum/flarum-ext-tags/blob/d0b62510d8a1a9d3a38cfdad0ed8447e85c5f7b0/src/Listener/SaveTagsToDatabase.php) need to be revised to use these phrases.