### PR TITLE
Adjust ID key name and move API key

### DIFF
--- a/locale/flarum-subscriptions.yml
+++ b/locale/flarum-subscriptions.yml
@@ -28,7 +28,7 @@ flarum-subscriptions:
 
     # These translations are used in the Settings page.
     settings:
-      forum_follow_after_reply_label: Automatically follow discussions that I reply to
+      follow_after_reply_label: Automatically follow discussions that I reply to
       notify_new_post_label: Someone posts in a discussion I'm following
 
     # These translations are used in the subscription menu displayed to the right of the post stream.

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -84,18 +84,18 @@ flarum-tags:
       removed_tags_text: "{username} removed the {tagsRemoved}."
       tags_text: "{tags} tag|{tags} tags"
 
+  # Translations in this namespace are used by the forum and admin interfaces.
+  lib:
+
+    # This translation is displayed in place of the name of a tag that's been deleted.
+    deleted_tag_text: Deleted
+
   # Translations in this namespace are used in messages output by the API.
   api:
 
     # These translations are used in messages regarding the number of tags assigned to a discussion.
     primary_tag_count_text: number of primary tags
     secondary_tag_count_text: number of secondary tags
-
-  # Translations in this namespace are used by the forum and admin interfaces.
-  lib:
-
-    # This translation is displayed in place of the name of a tag that's been deleted.
-    deleted_tag_text: Deleted
 
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!


### PR DESCRIPTION
- Adjusts the key for the "Follow after reply" setting.
- Supports flarum/flarum-ext-subscriptions/pull/10.
- Moves `api:` section below `views:`.