### PR TITLE
Move attributes to validation

### DIFF
--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -90,13 +90,6 @@ flarum-tags:
     # This translation is displayed in place of the name of a tag that's been deleted.
     deleted_tag_text: Deleted
 
-  # Translations in this namespace are used in messages output by the API.
-  api:
-
-    # These translations are used in messages regarding the number of tags assigned to a discussion.
-    primary_tag_count_text: number of primary tags
-    secondary_tag_count_text: number of secondary tags
-
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!
   ##

--- a/locale/validation.yml
+++ b/locale/validation.yml
@@ -71,6 +71,8 @@ validation:
     content: content
     name_singular: singular name
     name_plural: plural name
+    tag_count_primary: number of primary tags
+    tag_count_secondary: number of secondary tags
 
   custom:
     username:


### PR DESCRIPTION
- Moves attributes added in #79 to `validation.yml`.
- See flarum/core#973.
- `SaveTagsToDatabase.php` needs to be revised to use these phrases.
- Caution: key names have been changed as well!