### PR TITLE
Adjust namespacing for everything else

### DIFF
--- a/locale/flarum/akismet.yml
+++ b/locale/flarum/akismet.yml
@@ -1,22 +1,20 @@
-flarum-akismet:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Akismet Settings modal dialog.
+  akismet_settings:
+    api_key_label: API Key
+    title: Akismet Settings
 
-    # These translations are used in the Akismet Settings modal dialog.
-    akismet_settings:
-      api_key_label: API Key
-      title: Akismet Settings
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
-
-    # These translations are used by the frame displayed around flagged posts.
-    post:
-      akismet_flagged_text: Akismet flagged as spam
-      not_spam_button: Not Spam
+  # These translations are used by the frame displayed around flagged posts.
+  post:
+    akismet_flagged_text: Akismet flagged as spam
+    not_spam_button: Not Spam
 

--- a/locale/flarum/approval.yml
+++ b/locale/flarum/approval.yml
@@ -1,37 +1,35 @@
-flarum-approval:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Permissions page of the admin interface.
+  permissions:
+    approve_posts_label: Approve posts
+    reply_without_approval_label: Reply to discussions without approval
+    start_discussions_without_approval_label: Start discussions without approval
 
-    # These translations are used in the Permissions page of the admin interface.
-    permissions:
-      approve_posts_label: Approve posts
-      reply_without_approval_label: Reply to discussions without approval
-      start_discussions_without_approval_label: Start discussions without approval
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are displayed as tooltips for discussion badges.
+  badge:
+    awaiting_approval_tooltip: => approval::ref.awaiting_approval
 
-    # These translations are displayed as tooltips for discussion badges.
-    badge:
-      awaiting_approval_tooltip: => flarum-approval.ref.awaiting_approval
+  # These translations are displayed in the post header.
+  post:
+    awaiting_approval_text: => approval::ref.awaiting_approval
 
-    # These translations are displayed in the post header.
-    post:
-      awaiting_approval_text: => flarum-approval.ref.awaiting_approval
+  # These translations are used by the post control buttons.
+  post_controls:
+    approve_button: Approve
 
-    # These translations are used by the post control buttons.
-    post_controls:
-      approve_button: Approve
+##
+# REUSED TRANSLATIONS - These keys should not be used directly in code!
+##
 
-  ##
-  # REUSED TRANSLATIONS - These keys should not be used directly in code!
-  ##
-
-  # Translations in this namespace are referenced by two or more unique keys.
-  ref:
-    awaiting_approval: Awaiting approval
+# Translations in this namespace are referenced by two or more unique keys.
+ref:
+  awaiting_approval: Awaiting approval

--- a/locale/flarum/auth-facebook.yml
+++ b/locale/flarum/auth-facebook.yml
@@ -1,21 +1,19 @@
-flarum-auth-facebook:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Facebook Settings modal dialog.
+  facebook_settings:
+    app_id_label: App ID
+    app_secret_label: App Secret
+    title: Facebook Settings
 
-    # These translations are used in the Facebook Settings modal dialog.
-    facebook_settings:
-      app_id_label: App ID
-      app_secret_label: App Secret
-      title: Facebook Settings
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
-
-    # These translations are used in the Log In modal dialog.
-    log_in:
-      with_facebook_button: Log In with Facebook
+  # These translations are used in the Log In modal dialog.
+  log_in:
+    with_facebook_button: Log In with Facebook

--- a/locale/flarum/auth-github.yml
+++ b/locale/flarum/auth-github.yml
@@ -1,21 +1,19 @@
-flarum-auth-github:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the GitHub Settings modal dialog.
+  github_settings:
+    client_id_label: Client ID
+    client_secret_label: Client Secret
+    title: GitHub Settings
 
-    # These translations are used in the GitHub Settings modal dialog.
-    github_settings:
-      client_id_label: Client ID
-      client_secret_label: Client Secret
-      title: GitHub Settings
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
-
-    # These translations are used in the Log In modal dialog.
-    log_in:
-      with_github_button: Log In with GitHub
+  # These translations are used in the Log In modal dialog.
+  log_in:
+    with_github_button: Log In with GitHub

--- a/locale/flarum/auth-twitter.yml
+++ b/locale/flarum/auth-twitter.yml
@@ -1,21 +1,19 @@
-flarum-auth-twitter:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Twitter Settings modal dialog.
+  twitter_settings:
+    api_key_label: API Key
+    api_secret_label: API Secret
+    title: Twitter Settings
 
-    # These translations are used in the Twitter Settings modal dialog.
-    twitter_settings:
-      api_key_label: API Key
-      api_secret_label: API Secret
-      title: Twitter Settings
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
-
-    # These translations are used in the Log In modal dialog.
-    log_in:
-      with_twitter_button: Log In with Twitter
+  # These translations are used in the Log In modal dialog.
+  log_in:
+    with_twitter_button: Log In with Twitter

--- a/locale/flarum/core.yml
+++ b/locale/flarum/core.yml
@@ -1,538 +1,536 @@
-core:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the placeholder Add Extension modal dialog.
+  add_extension:
+    developer_text: "If you're a developer, you can <a>read the docs</a> and have a go at building your own extensions."
+    install_text: "In the meantime, you can look for extensions at the <a>Flarum Community site</a> and install them manually using Composer."
+    temporary_text: "One day in the not-too-distant future, this dialog will allow you to add an extension to your forum with ease. We're building an ecosystem as we speak!"
 
-    # These translations are used in the placeholder Add Extension modal dialog.
-    add_extension:
-      developer_text: "If you're a developer, you can <a>read the docs</a> and have a go at building your own extensions."
-      install_text: "In the meantime, you can look for extensions at the <a>Flarum Community site</a> and install them manually using Composer."
-      temporary_text: "One day in the not-too-distant future, this dialog will allow you to add an extension to your forum with ease. We're building an ecosystem as we speak!"
+  # These translations are used in the Appearance page.
+  appearance:
+    colored_header_label: Colored Header
+    colors_heading: Colors
+    colors_text: "Choose two colors to theme your forum with. The first will be used as a highlight color, while the second will be used to style background elements."
+    custom_header_heading: Custom Header
+    custom_header_text: "Add HTML to be displayed at the very top of the page, above Flarum's own header."
+    custom_styles_heading: Custom Styles
+    custom_styles_text: Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's default styles.
+    dark_mode_label: Dark Mode
+    edit_css_button: Edit Custom CSS
+    edit_header_button: Edit Custom Header
+    enter_hex_message: Please enter a hexadecimal color code.
+    favicon_heading: Favicon
+    favicon_text: Upload an image to be displayed as the forum's shortcut icon.
+    logo_heading: Logo
+    logo_text: Upload an image to be displayed in place of the forum title.
+    submit_button: => ref.save_changes
 
-    # These translations are used in the Appearance page.
-    appearance:
-      colored_header_label: Colored Header
-      colors_heading: Colors
-      colors_text: "Choose two colors to theme your forum with. The first will be used as a highlight color, while the second will be used to style background elements."
-      custom_header_heading: Custom Header
-      custom_header_text: "Add HTML to be displayed at the very top of the page, above Flarum's own header."
-      custom_styles_heading: Custom Styles
-      custom_styles_text: Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's default styles.
-      dark_mode_label: Dark Mode
-      edit_css_button: Edit Custom CSS
-      edit_header_button: Edit Custom Header
-      enter_hex_message: Please enter a hexadecimal color code.
-      favicon_heading: Favicon
-      favicon_text: Upload an image to be displayed as the forum's shortcut icon.
-      logo_heading: Logo
-      logo_text: Upload an image to be displayed in place of the forum title.
-      submit_button: => core.ref.save_changes
+  # These translations are used in the Basics page.
+  basics:
+    all_discussions_label: => ref.all_discussions
+    default_language_heading: Default Language
+    forum_description_heading: Forum Description
+    forum_description_text: Enter a short sentence or two that describes your community. This will appear in the meta tag and show up in search engines.
+    forum_title_heading: Forum Title
+    home_page_heading: Home Page
+    home_page_text: "Choose the page which users will first see when they visit your forum. If entering a custom value, use the path relative to the forum root."
+    saved_message: Your changes were saved.
+    submit_button: => ref.save_changes
+    welcome_banner_heading: Welcome Banner
+    welcome_banner_text: Configure the text that displays in the banner on the All Discussions page. Use this to welcome guests to your forum.
 
-    # These translations are used in the Basics page.
-    basics:
-      all_discussions_label: => core.ref.all_discussions
-      default_language_heading: Default Language
-      forum_description_heading: Forum Description
-      forum_description_text: Enter a short sentence or two that describes your community. This will appear in the meta tag and show up in search engines.
-      forum_title_heading: Forum Title
-      home_page_heading: Home Page
-      home_page_text: "Choose the page which users will first see when they visit your forum. If entering a custom value, use the path relative to the forum root."
-      saved_message: Your changes were saved.
-      submit_button: => core.ref.save_changes
-      welcome_banner_heading: Welcome Banner
-      welcome_banner_text: Configure the text that displays in the banner on the All Discussions page. Use this to welcome guests to your forum.
+  # These translations are used in the Dashboard page.
+  dashboard:
+    beta_warning_text: "This <strong>beta software</strong> is provided primarily so that you can help us test it and make it better; it should not be used in production."
+    contributing_text: "Want to look for bugs and contribute? Read the <a>Contributing docs</a>."
+    extension_text: "Interested in developing extensions? Read the <a>Extension docs</a>."
+    features_text: "Got an idea to improve a feature? Tell us about it under the <a>Features tag</a>."
+    support_text: "Found a bug? Please report it in our forum, under the <a>Support tag</a>."
+    troubleshooting_text: "Having problems? Follow the instructions in the <a>Troubleshooting docs</a>."
+    version_text: "Thanks for trying out Flarum! You are running version {version}."
+    welcome_text: "Welcome to Flarum Beta!"
 
-    # These translations are used in the Dashboard page.
-    dashboard:
-      beta_warning_text: "This <strong>beta software</strong> is provided primarily so that you can help us test it and make it better; it should not be used in production."
-      contributing_text: "Want to look for bugs and contribute? Read the <a>Contributing docs</a>."
-      extension_text: "Interested in developing extensions? Read the <a>Extension docs</a>."
-      features_text: "Got an idea to improve a feature? Tell us about it under the <a>Features tag</a>."
-      support_text: "Found a bug? Please report it in our forum, under the <a>Support tag</a>."
-      troubleshooting_text: "Having problems? Follow the instructions in the <a>Troubleshooting docs</a>."
-      version_text: "Thanks for trying out Flarum! You are running version {version}."
-      welcome_text: "Welcome to Flarum Beta!"
+  # These translations are used in the Edit Custom CSS modal dialog.
+  edit_css:
+    customize_text: "Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's <a>default styles</a>."
+    submit_button: => ref.save_changes
+    title: Edit Custom CSS
 
-    # These translations are used in the Edit Custom CSS modal dialog.
-    edit_css:
-      customize_text: "Customize your forum's appearance by adding your own LESS/CSS code to be applied on top of Flarum's <a>default styles</a>."
-      submit_button: => core.ref.save_changes
-      title: Edit Custom CSS
+  # These translations are used in the Edit Group modal dialog.
+  edit_group:
+    color_label: Color
+    delete_button: Delete Group
+    delete_confirmation: "Are you sure you want to delete this group? The group members will NOT be deleted."
+    icon_label: Icon
+    icon_text: "Enter the name of any <a>FontAwesome</a> icon class, <em>without</em> the <code>fa-</code> prefix."
+    name_label: Name
+    plural_placeholder: Plural (e.g. Mods)
+    singular_placeholder: Singular (e.g. Mod)
+    submit_button: => ref.save_changes
+    title: Create Group
 
-    # These translations are used in the Edit Group modal dialog.
-    edit_group:
-      color_label: Color
-      delete_button: Delete Group
-      delete_confirmation: "Are you sure you want to delete this group? The group members will NOT be deleted."
-      icon_label: Icon
-      icon_text: "Enter the name of any <a>FontAwesome</a> icon class, <em>without</em> the <code>fa-</code> prefix."
-      name_label: Name
-      plural_placeholder: Plural (e.g. Mods)
-      singular_placeholder: Singular (e.g. Mod)
-      submit_button: => core.ref.save_changes
-      title: Create Group
+  # These translations are used in the Edit Custom Header modal dialog.
+  edit_header:
+    customize_text: "Add HTML to be displayed at the very top of the page, above Flarum's own header."
+    submit_button: => ref.save_changes
+    title: Edit Custom Header
 
-    # These translations are used in the Edit Custom Header modal dialog.
-    edit_header:
-      customize_text: "Add HTML to be displayed at the very top of the page, above Flarum's own header."
-      submit_button: => core.ref.save_changes
-      title: Edit Custom Header
-
-    # These translations are used in the email page of the admin interface.
-    email:
-      account_heading: SMTP Account
-      addresses_heading: Addresses
-      driver_label: Driver
-      encryption_label: Encryption
-      from_label: Sender
-      heading: => core.ref.email
-      host_label: Host
-      password_label: => core.ref.password
-      port_label: Port
-      server_heading: SMTP Server
-      submit_button: => core.ref.save_changes
-      text: Configure the SMTP settings and addresses your forum will use to send email.
-      username_label: => core.ref.username
-
-    # These translations are used in the Extensions page.
-    extensions:
-      add_button: Add Extension
-      settings_button: => core.ref.settings
-      uninstall_button: Uninstall
-
-    # These translations are used in the session dropdown menu.
-    header:
-      log_out_button: => core.ref.log_out
-
-    # These translations are used in the modal dialog displayed when loading extensions.
-    loading:
-      title: Please Wait...
-
-    # These translations are used in the navigation bar.
-    nav:
-      appearance_button: Appearance
-      appearance_text: "Customize your forum's colors, logos, and other variables."
-      basics_button: Basics
-      basics_text: "Set your forum title, language, and other basic settings."
-      dashboard_button: Dashboard
-      dashboard_text: Your forum at a glance.
-      email_button: => core.ref.email
-      email_text: "Configure your forum's email settings."
-      extensions_button: Extensions
-      extensions_text: Add extra functionality to your forum and make it your own.
-      permissions_button: Permissions
-      permissions_text: Configure who can see and do what.
-
-    # These translations are used in the Permissions page of the admin interface.
-    permissions:
-      allow_renaming_label: Allow renaming
-      allow_post_editing_label: Allow post editing
-      create_heading: Create
-      delete_discussions_forever_label: Delete discussions forever
-      delete_discussions_label: Delete discussions
-      delete_posts_forever_label: Delete posts forever
-      edit_and_delete_posts_label: Edit and delete posts
-      global_heading: Global
-      moderate_heading: Moderate
-      new_group_button: New Group
-      participate_heading: Participate
-      read_heading: Read
-      rename_discussions_label: Rename discussions
-      reply_to_discussions_label: Reply to discussions
-      sign_up_label: Sign up
-      start_discussions_label: Start discussions
-      view_discussions_label: View discussions
-      view_post_ips_label: View post IP addresses
-
-    # These translations are used in the dropdown menus on the Permissions page.
-    permissions_controls:
-      allow_indefinitely_button: Indefinitely
-      allow_some_minutes_button: "For {count} minute|For {count} minutes"
-      allow_ten_minutes_button: For 10 minutes
-      allow_until_reply_button: Until next reply
-      everyone_button: Everyone
-      members_button: => core.group.members
-      signup_closed_button: Closed
-      signup_open_button: Open
-
-    # These translations are used in the Settings modal dialog.
-    settings:
-      submit_button: => core.ref.save_changes
-
-    # These translations are used in image upload buttons.
-    upload_image:
-      remove_button: Remove
-      upload_button: Choose an Image...
-
-  # Translations in this namespace are used by the forum user interface.
-  forum:
-
-    # These translations are used in the Change Email modal dialog.
-    change_email:
-      confirmation_message: => core.ref.confirmation_email_sent
-      confirm_password_placeholder: => core.ref.confirm_password
-      dismiss_button: => core.ref.okay
-      incorrect_password_message: The password you entered is incorrect.
-      submit_button: => core.ref.save_changes
-      title: => core.ref.change_email
-
-    # These translations are used in the Change Password modal dialog.
-    change_password:
-      send_button: Send Password Reset Email
-      text: Click the button below and check your email for a link to change your password.
-      title: => core.ref.change_password
-
-    # These translations are used by the composer controls.
-    composer:
-      close_tooltip: Close
-      exit_full_screen_tooltip: Exit Full Screen
-      full_screen_tooltip: Full Screen
-      minimize_tooltip: Minimize
-
-    # These translations are used by the composer when starting a discussion.
-    composer_discussion:
-      body_placeholder: Write a Post...
-      discard_confirmation: "You have not posted your discussion. Do you wish to discard it?"
-      submit_button: Post Discussion
-      title: => core.ref.start_a_discussion
-      title_placeholder: Discussion Title
-
-    # These translations are used by the composer when editing a post.
-    composer_edit:
-      discard_confirmation: "You have not saved your changes. Do you wish to discard them?"
-      post_link: "Post #{number} in {discussion}"
-      submit_button: => core.ref.save_changes
-
-    # These translations are used by the composer when replying to a discussion.
-    composer_reply:
-      body_placeholder: => core.ref.write_a_reply
-      discard_confirmation: "You have not posted your reply. Do you wish to discard it?"
-      posted_message: Your reply was posted.
-      submit_button: Post Reply
-      view_button: View
-
-    # These translations are used by the discussion control buttons.
-    discussion_controls:
-      cannot_reply_button: Can't Reply
-      cannot_reply_text: You don't have permission to reply to this discussion.
-      delete_button: => core.ref.delete
-      delete_confirmation: "Are you sure you want to delete this discussion?"
-      delete_forever_button: => core.ref.delete_forever
-      log_in_to_reply_button: Log In to Reply
-      rename_button: Rename
-      rename_text: "Enter a new title for this discussion:"
-      reply_button: => core.ref.reply
-      restore_button: => core.ref.restore
-
-    # These translations are used in the discussion list.
-    discussion_list:
-      empty_text: It looks like there are no discussions here.
-      load_more_button: => core.ref.load_more
-      mark_as_read_tooltip: Mark as Read
-      replied_text: "{username} replied {ago}"
-      started_text: "{username} started {ago}"
-
-    # These translations are used in the Edit User modal dialog (admin function).
-    edit_user:
-      email_label: => core.ref.email
-      password_label: => core.ref.password
-      submit_button: => core.ref.save_changes
-      title: Edit User
-      username_label: => core.ref.username
-
-    # These translations are used in the Forgot Password modal dialog.
-    forgot_password:
-      dismiss_button: => core.ref.okay
-      email_placeholder: => core.ref.email
-      email_sent_message: We've sent you an email containing a link to reset your password. Check your spam folder if you don't receive it within the next minute or two.
-      not_found_message: There is no user registered with that email address.
-      submit_button: Recover Password
-      text: Enter your email address and we will send you a link to reset your password.
-      title: Forgot Password
-
-    # These translations are used in the header and session dropdown menu.
-    header:
-      admin_button: Administration
-      log_in_link: => core.ref.log_in
-      log_out_button: => core.ref.log_out
-      profile_button: Profile
-      search_placeholder: Search Forum
-      settings_button: => core.ref.settings
-      sign_up_link: => core.ref.sign_up
-
-    # These translations are used on the index page, peripheral to the discussion list.
-    index:
-      all_discussions_link: => core.ref.all_discussions
-      cannot_start_discussion_button: Can't Start Discussion
-      mark_all_as_read_confirmation: "Are you sure you want to mark all discussions as read?"
-      mark_all_as_read_tooltip: => core.ref.mark_all_as_read
-      refresh_tooltip: Refresh
-      start_discussion_button: => core.ref.start_a_discussion
-
-    # These translations are used by the sorting control above the discussion list.
-    index_sort:
-      latest_button: Latest
-      newest_button: Newest
-      oldest_button: Oldest
-      relevance_button: Relevance
-      top_button: Top
-
-    # These translations are used in the Log In modal dialog.
-    log_in:
-      forgot_password_link: "Forgot password?"
-      invalid_login_message: Your login details were incorrect.
-      password_placeholder: => core.ref.password
-      remember_me_label: Remember me for two weeks
-      sign_up_text: "Don't have an account? <a>Sign Up</a>"
-      submit_button: => core.ref.log_in
-      title: => core.ref.log_in
-      username_or_email_placeholder: Username or Email
-
-    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
-    notifications:
-      discussion_renamed_text: "{username} changed the title"
-      empty_text: No Notifications
-      mark_all_as_read_tooltip: => core.ref.mark_all_as_read
-      title: => core.ref.notifications
-      tooltip: => core.ref.notifications
-
-    # These translations are used by tooltips displayed for individual posts.
-    post:
-      edited_text: Edited
-      edited_tooltip: "{username} edited {ago}"
-      number_tooltip: "Post #{number}"
-
-    # These translations are used by the post control buttons.
-    post_controls:
-      delete_button: => core.ref.delete
-      delete_forever_button: => core.ref.delete_forever
-      edit_button: => core.ref.edit
-      restore_button: => core.ref.restore
-
-    # These translations are used in the scrubber to the right of the post stream.
-    post_scrubber:
-      now_link: Now
-      original_post_link: Original Post
-      unread_text: "{count} unread"
-      viewing_text: "{index} of {count} post|{index} of {count} posts"
-
-    # These translations are displayed between posts in the post stream.
-    post_stream:
-      discussion_renamed_old_tooltip: 'The old title was: "{old}"'
-      discussion_renamed_text: "{username} changed the title to {new}."
-      load_more_button: => core.ref.load_more
-      reply_placeholder: => core.ref.write_a_reply
-      time_lapsed_text: "{period} later"
-
-    # These translations are used by the search results dropdown list.
-    search:
-      all_discussions_button: 'Search all discussions for "{query}"'
-      discussions_heading: => core.ref.discussions
-      users_heading: Users
-
-    # These translations are used in the Settings page.
-    settings:
-      account_heading: Account
-      change_email_button: => core.ref.change_email
-      change_password_button: => core.ref.change_password
-      notifications_heading: => core.ref.notifications
-      notify_by_email_heading: => core.ref.email
-      notify_by_web_heading: Web
-      notify_discussion_renamed_label: Someone renames a discussion I started
-      privacy_disclose_online_label: Allow others to see when I am online
-      privacy_heading: Privacy
-      title: => core.ref.settings
-
-    # These translations are used in the Sign Up modal dialog.
-    sign_up:
-      email_placeholder: => core.ref.email
-      dismiss_button: => core.ref.okay
-      log_in_text: "Already have an account? <a>Log In</a>"
-      password_placeholder: => core.ref.password
-      submit_button: => core.ref.sign_up
-      title: => core.ref.sign_up
-      username_placeholder: => core.ref.username
-      welcome_text: "Welcome, {username}!"
-
-    # These translations are used in the user profile page and profile popup.
-    user:
-      avatar_remove_button: Remove
-      avatar_upload_button: Upload
-      avatar_upload_tooltip: Upload a new avatar
-      bio_placeholder: Write something about yourself
-      discussions_link: => core.ref.discussions
-      in_discussion_text: "In {discussion}"
-      joined_date_text: "Joined {ago}"
-      online_text: Online
-      posts_load_more_button: => core.ref.load_more
-      posts_link: Posts
-      settings_link: => core.ref.settings
-
-    # These translations are found on the user profile page (admin function).
-    user_controls:
-      button: Controls
-      delete_button: => core.ref.delete
-      delete_confirmation: "Are you sure you want to delete this user? All of the user's posts will be deleted."
-      edit_button: => core.ref.edit
-
-    # These translations are used in the alert that is shown when a new user has not confirmed their email address.
-    user_email_confirmation:
-      alert_message: => core.ref.confirmation_email_sent
-      resend_button: Resend Confirmation Email
-      sent_message: Sent
-
-  # Translations in this namespace are used by the forum and admin interfaces.
-  lib:
-
-    # These translations are displayed as tooltips for discussion badges.
-    badge:
-      hidden_tooltip: Hidden
-
-    # These translations are used to modify usernames.
-    username:
-      deleted_text: "[deleted]"
-
-    # These translations are displayed as error messages.
-    error:
-      generic_message: "Oops! Something went wrong. Please reload the page and try again."
-      not_found_message: The requested resource was not found.
-      permission_denied_message: You do not have permission to do that.
-      rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.
-
-    # These translations are used as suffixes when abbreviating numbers.
-    number_suffix:
-      kilo_text: K
-      mega_text: M
-
-    # These translations are used to punctuate a series of items.
-    series:
-      glue_text: ", "
-      three_text: "{first}, {second}, and {third}"
-      two_text: "{first} and {second}"
-
-  # Translations in this namespace are used in views other than Flarum's normal JS client.
-  views:
-
-    # Translations in this namespace are displayed by the basic HTML content loader.
-    content:
-      javascript_disabled_message: This site is best viewed in a modern browser with JavaScript enabled.
-      load_error_message: Something went wrong while trying to load the full version of this site.
-      loading_text: Loading...
-
-    # Translations in this namespace are displayed in the basic HTML discussion view.
-    discussion:
-      next_page_button: => core.ref.next_page
-      previous_page_button: Previous Page
-
-    # Translations in this namespace are displayed by the basic HTML discussion index.
-    index:
-      all_discussions_heading: => core.ref.all_discussions
-      next_page_button: => core.ref.next_page
-
-    # Translations in this namespace are displayed by the Reset Password interface.
-    reset:
-      confirm_password_label: => core.ref.confirm_password
-      password_label: => core.ref.password
-      submit_button: Reset Password
-      title: => core.ref.reset_your_password
-
-  # Translations in this namespace are used in messages output by the API.
-  api:
-    invalid_username_message: "The username may only contain letters, numbers, and dashes."
-
-  # Translations in this namespace are used in emails sent by the forum.
+  # These translations are used in the email page of the admin interface.
   email:
+    account_heading: SMTP Account
+    addresses_heading: Addresses
+    driver_label: Driver
+    encryption_label: Encryption
+    from_label: Sender
+    heading: => ref.email
+    host_label: Host
+    password_label: => ref.password
+    port_label: Port
+    server_heading: SMTP Server
+    submit_button: => ref.save_changes
+    text: Configure the SMTP settings and addresses your forum will use to send email.
+    username_label: => ref.username
 
-    # These translations are used in emails sent when users register new accounts.
-    activate_account:
-      subject: Activate Your New Account
-      body: |
-        Hey {username}!
+  # These translations are used in the Extensions page.
+  extensions:
+    add_button: Add Extension
+    settings_button: => ref.settings
+    uninstall_button: Uninstall
 
-        Someone (hopefully you!) has signed up to {forum} with this email address.
+  # These translations are used in the session dropdown menu.
+  header:
+    log_out_button: => ref.log_out
 
-        If this was you, simply click the following link and your account will be activated:
-        {url}
+  # These translations are used in the modal dialog displayed when loading extensions.
+  loading:
+    title: Please Wait...
 
-        If you did not sign up, please ignore this email.
+  # These translations are used in the navigation bar.
+  nav:
+    appearance_button: Appearance
+    appearance_text: "Customize your forum's colors, logos, and other variables."
+    basics_button: Basics
+    basics_text: "Set your forum title, language, and other basic settings."
+    dashboard_button: Dashboard
+    dashboard_text: Your forum at a glance.
+    email_button: => ref.email
+    email_text: "Configure your forum's email settings."
+    extensions_button: Extensions
+    extensions_text: Add extra functionality to your forum and make it your own.
+    permissions_button: Permissions
+    permissions_text: Configure who can see and do what.
 
-    # These translations are used in emails sent when users change their email address.
-    confirm_email:
-      subject: Confirm Your New Email Address
-      body: |
-        Hey {username}!
+  # These translations are used in the Permissions page of the admin interface.
+  permissions:
+    allow_renaming_label: Allow renaming
+    allow_post_editing_label: Allow post editing
+    create_heading: Create
+    delete_discussions_forever_label: Delete discussions forever
+    delete_discussions_label: Delete discussions
+    delete_posts_forever_label: Delete posts forever
+    edit_and_delete_posts_label: Edit and delete posts
+    global_heading: Global
+    moderate_heading: Moderate
+    new_group_button: New Group
+    participate_heading: Participate
+    read_heading: Read
+    rename_discussions_label: Rename discussions
+    reply_to_discussions_label: Reply to discussions
+    sign_up_label: Sign up
+    start_discussions_label: Start discussions
+    view_discussions_label: View discussions
+    view_post_ips_label: View post IP addresses
 
-        Someone (hopefully you!) has changed their email address on {forum} to this one.
+  # These translations are used in the dropdown menus on the Permissions page.
+  permissions_controls:
+    allow_indefinitely_button: Indefinitely
+    allow_some_minutes_button: "For {count} minute|For {count} minutes"
+    allow_ten_minutes_button: For 10 minutes
+    allow_until_reply_button: Until next reply
+    everyone_button: Everyone
+    members_button: => groups.members
+    signup_closed_button: Closed
+    signup_open_button: Open
 
-        If this was you, simply click the following link and your email will be confirmed:
-        {url}
+  # These translations are used in the Settings modal dialog.
+  settings:
+    submit_button: => ref.save_changes
 
-        If this was not you, please ignore this email.
+  # These translations are used in image upload buttons.
+  upload_image:
+    remove_button: Remove
+    upload_button: Choose an Image...
 
-    # These translations are used in emails sent when users ask to reset their passwords.
-    reset_password:
-      subject: => core.ref.reset_your_password
-      body: |
-        Hey {username}!
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-        Someone (hopefully you!) has submitted a forgotten password request for your account on {forum}.
+  # These translations are used in the Change Email modal dialog.
+  change_email:
+    confirmation_message: => ref.confirmation_email_sent
+    confirm_password_placeholder: => ref.confirm_password
+    dismiss_button: => ref.okay
+    incorrect_password_message: The password you entered is incorrect.
+    submit_button: => ref.save_changes
+    title: => ref.change_email
 
-        If this was you, click the following link to reset your password:
-        {url}
+  # These translations are used in the Change Password modal dialog.
+  change_password:
+    send_button: Send Password Reset Email
+    text: Click the button below and check your email for a link to change your password.
+    title: => ref.change_password
 
-        If you do not wish to change your password, just ignore this email and nothing will happen.
+  # These translations are used by the composer controls.
+  composer:
+    close_tooltip: Close
+    exit_full_screen_tooltip: Exit Full Screen
+    full_screen_tooltip: Full Screen
+    minimize_tooltip: Minimize
 
-  ##
-  # REUSED TRANSLATIONS - These keys should not be used directly in code!
-  ##
+  # These translations are used by the composer when starting a discussion.
+  composer_discussion:
+    body_placeholder: Write a Post...
+    discard_confirmation: "You have not posted your discussion. Do you wish to discard it?"
+    submit_button: Post Discussion
+    title: => ref.start_a_discussion
+    title_placeholder: Discussion Title
 
-  # Translations in this namespace are referenced by two or more unique keys.
-  ref:
-    all_discussions: All Discussions
-    change_email: Change Email
-    change_password: Change Password
-    confirm_password: Confirm Password
-    confirmation_email_sent: "We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
-    delete: Delete
-    delete_forever: Delete Forever
-    discussions: Discussions
-    edit: Edit
-    email: Email
-    load_more: Load More
-    log_in: Log In
-    log_out: Log Out
-    mark_all_as_read: Mark All as Read
-    next_page: Next Page
-    notifications: Notifications
-    okay: OK                                     # Referenced by flarum-tags.yml
-    password: Password
-    reply: Reply                                 # Referenced by flarum-mentions.yml
-    reset_your_password: Reset Your Password
-    restore: Restore
-    save_changes: Save Changes                   # Referenced by flarum-suspend.yml, flarum-tags.yml
-    settings: Settings
-    sign_up: Sign Up
-    some_others: "{count} other|{count} others"  # Referenced by flarum-likes.yml, flarum-mentions.yml
-    start_a_discussion: Start a Discussion
-    username: Username
-    write_a_reply: Write a Reply...
-    you: You                                     # Referenced by flarum-likes.yml, flarum-mentions.yml
+  # These translations are used by the composer when editing a post.
+  composer_edit:
+    discard_confirmation: "You have not saved your changes. Do you wish to discard them?"
+    post_link: "Post #{number} in {discussion}"
+    submit_button: => ref.save_changes
 
-  ##
-  # GROUP NAMES - These keys are translated at the back end.
-  ##
+  # These translations are used by the composer when replying to a discussion.
+  composer_reply:
+    body_placeholder: => ref.write_a_reply
+    discard_confirmation: "You have not posted your reply. Do you wish to discard it?"
+    posted_message: Your reply was posted.
+    submit_button: Post Reply
+    view_button: View
 
-  # Translations in this namespace are used to translate default group names.
-  group:
-    admin: Admin
-    admins: Admins
-    guest: Guest
-    guests: Guests
-    member: Member
-    members: Members
-    mod: Mod
-    mods: Mods
+  # These translations are used by the discussion control buttons.
+  discussion_controls:
+    cannot_reply_button: Can't Reply
+    cannot_reply_text: You don't have permission to reply to this discussion.
+    delete_button: => ref.delete
+    delete_confirmation: "Are you sure you want to delete this discussion?"
+    delete_forever_button: => ref.delete_forever
+    log_in_to_reply_button: Log In to Reply
+    rename_button: Rename
+    rename_text: "Enter a new title for this discussion:"
+    reply_button: => ref.reply
+    restore_button: => ref.restore
+
+  # These translations are used in the discussion list.
+  discussion_list:
+    empty_text: It looks like there are no discussions here.
+    load_more_button: => ref.load_more
+    mark_as_read_tooltip: Mark as Read
+    replied_text: "{username} replied {ago}"
+    started_text: "{username} started {ago}"
+
+  # These translations are used in the Edit User modal dialog (admin function).
+  edit_user:
+    email_label: => ref.email
+    password_label: => ref.password
+    submit_button: => ref.save_changes
+    title: Edit User
+    username_label: => ref.username
+
+  # These translations are used in the Forgot Password modal dialog.
+  forgot_password:
+    dismiss_button: => ref.okay
+    email_placeholder: => ref.email
+    email_sent_message: We've sent you an email containing a link to reset your password. Check your spam folder if you don't receive it within the next minute or two.
+    not_found_message: There is no user registered with that email address.
+    submit_button: Recover Password
+    text: Enter your email address and we will send you a link to reset your password.
+    title: Forgot Password
+
+  # These translations are used in the header and session dropdown menu.
+  header:
+    admin_button: Administration
+    log_in_link: => ref.log_in
+    log_out_button: => ref.log_out
+    profile_button: Profile
+    search_placeholder: Search Forum
+    settings_button: => ref.settings
+    sign_up_link: => ref.sign_up
+
+  # These translations are used on the index page, peripheral to the discussion list.
+  index:
+    all_discussions_link: => ref.all_discussions
+    cannot_start_discussion_button: Can't Start Discussion
+    mark_all_as_read_confirmation: "Are you sure you want to mark all discussions as read?"
+    mark_all_as_read_tooltip: => ref.mark_all_as_read
+    refresh_tooltip: Refresh
+    start_discussion_button: => ref.start_a_discussion
+
+  # These translations are used by the sorting control above the discussion list.
+  index_sort:
+    latest_button: Latest
+    newest_button: Newest
+    oldest_button: Oldest
+    relevance_button: Relevance
+    top_button: Top
+
+  # These translations are used in the Log In modal dialog.
+  log_in:
+    forgot_password_link: "Forgot password?"
+    invalid_login_message: Your login details were incorrect.
+    password_placeholder: => ref.password
+    remember_me_label: Remember me for two weeks
+    sign_up_text: "Don't have an account? <a>Sign Up</a>"
+    submit_button: => ref.log_in
+    title: => ref.log_in
+    username_or_email_placeholder: Username or Email
+
+  # These translations are used by the Notifications dropdown, a.k.a. "the bell".
+  notifications:
+    discussion_renamed_text: "{username} changed the title"
+    empty_text: No Notifications
+    mark_all_as_read_tooltip: => ref.mark_all_as_read
+    title: => ref.notifications
+    tooltip: => ref.notifications
+
+  # These translations are used by tooltips displayed for individual posts.
+  post:
+    edited_text: Edited
+    edited_tooltip: "{username} edited {ago}"
+    number_tooltip: "Post #{number}"
+
+  # These translations are used by the post control buttons.
+  post_controls:
+    delete_button: => ref.delete
+    delete_forever_button: => ref.delete_forever
+    edit_button: => ref.edit
+    restore_button: => ref.restore
+
+  # These translations are used in the scrubber to the right of the post stream.
+  post_scrubber:
+    now_link: Now
+    original_post_link: Original Post
+    unread_text: "{count} unread"
+    viewing_text: "{index} of {count} post|{index} of {count} posts"
+
+  # These translations are displayed between posts in the post stream.
+  post_stream:
+    discussion_renamed_old_tooltip: 'The old title was: "{old}"'
+    discussion_renamed_text: "{username} changed the title to {new}."
+    load_more_button: => ref.load_more
+    reply_placeholder: => ref.write_a_reply
+    time_lapsed_text: "{period} later"
+
+  # These translations are used by the search results dropdown list.
+  search:
+    all_discussions_button: 'Search all discussions for "{query}"'
+    discussions_heading: => ref.discussions
+    users_heading: Users
+
+  # These translations are used in the Settings page.
+  settings:
+    account_heading: Account
+    change_email_button: => ref.change_email
+    change_password_button: => ref.change_password
+    notifications_heading: => ref.notifications
+    notify_by_email_heading: => ref.email
+    notify_by_web_heading: Web
+    notify_discussion_renamed_label: Someone renames a discussion I started
+    privacy_disclose_online_label: Allow others to see when I am online
+    privacy_heading: Privacy
+    title: => ref.settings
+
+  # These translations are used in the Sign Up modal dialog.
+  sign_up:
+    email_placeholder: => ref.email
+    dismiss_button: => ref.okay
+    log_in_text: "Already have an account? <a>Log In</a>"
+    password_placeholder: => ref.password
+    submit_button: => ref.sign_up
+    title: => ref.sign_up
+    username_placeholder: => ref.username
+    welcome_text: "Welcome, {username}!"
+
+  # These translations are used in the user profile page and profile popup.
+  user:
+    avatar_remove_button: Remove
+    avatar_upload_button: Upload
+    avatar_upload_tooltip: Upload a new avatar
+    bio_placeholder: Write something about yourself
+    discussions_link: => ref.discussions
+    in_discussion_text: "In {discussion}"
+    joined_date_text: "Joined {ago}"
+    online_text: Online
+    posts_load_more_button: => ref.load_more
+    posts_link: Posts
+    settings_link: => ref.settings
+
+  # These translations are found on the user profile page (admin function).
+  user_controls:
+    button: Controls
+    delete_button: => ref.delete
+    delete_confirmation: "Are you sure you want to delete this user? All of the user's posts will be deleted."
+    edit_button: => ref.edit
+
+  # These translations are used in the alert that is shown when a new user has not confirmed their email address.
+  user_email_confirmation:
+    alert_message: => ref.confirmation_email_sent
+    resend_button: Resend Confirmation Email
+    sent_message: Sent
+
+# Translations in this namespace are used by the forum and admin interfaces.
+lib:
+
+  # These translations are displayed as tooltips for discussion badges.
+  badge:
+    hidden_tooltip: Hidden
+
+  # These translations are used to modify usernames.
+  username:
+    deleted_text: "[deleted]"
+
+  # These translations are displayed as error messages.
+  error:
+    generic_message: "Oops! Something went wrong. Please reload the page and try again."
+    not_found_message: The requested resource was not found.
+    permission_denied_message: You do not have permission to do that.
+    rate_limit_exceeded_message: You're going a little too quickly. Please try again in a few seconds.
+
+  # These translations are used as suffixes when abbreviating numbers.
+  number_suffix:
+    kilo_text: K
+    mega_text: M
+
+  # These translations are used to punctuate a series of items.
+  series:
+    glue_text: ", "
+    three_text: "{first}, {second}, and {third}"
+    two_text: "{first} and {second}"
+
+# Translations in this namespace are used in views other than Flarum's normal JS client.
+views:
+
+  # Translations in this namespace are displayed by the basic HTML content loader.
+  content:
+    javascript_disabled_message: This site is best viewed in a modern browser with JavaScript enabled.
+    load_error_message: Something went wrong while trying to load the full version of this site.
+    loading_text: Loading...
+
+  # Translations in this namespace are displayed in the basic HTML discussion view.
+  discussion:
+    next_page_button: => ref.next_page
+    previous_page_button: Previous Page
+
+  # Translations in this namespace are displayed by the basic HTML discussion index.
+  index:
+    all_discussions_heading: => ref.all_discussions
+    next_page_button: => ref.next_page
+
+  # Translations in this namespace are displayed by the Reset Password interface.
+  reset:
+    confirm_password_label: => ref.confirm_password
+    password_label: => ref.password
+    submit_button: Reset Password
+    title: => ref.reset_your_password
+
+# Translations in this namespace are used in messages output by the API.
+api:
+  invalid_username_message: "The username may only contain letters, numbers, and dashes."
+
+# Translations in this namespace are used in emails sent by the forum.
+email:
+
+  # These translations are used in emails sent when users register new accounts.
+  activate_account:
+    subject: Activate Your New Account
+    body: |
+      Hey {username}!
+
+      Someone (hopefully you!) has signed up to {forum} with this email address.
+
+      If this was you, simply click the following link and your account will be activated:
+      {url}
+
+      If you did not sign up, please ignore this email.
+
+  # These translations are used in emails sent when users change their email address.
+  confirm_email:
+    subject: Confirm Your New Email Address
+    body: |
+      Hey {username}!
+
+      Someone (hopefully you!) has changed their email address on {forum} to this one.
+
+      If this was you, simply click the following link and your email will be confirmed:
+      {url}
+
+      If this was not you, please ignore this email.
+
+  # These translations are used in emails sent when users ask to reset their passwords.
+  reset_password:
+    subject: => ref.reset_your_password
+    body: |
+      Hey {username}!
+
+      Someone (hopefully you!) has submitted a forgotten password request for your account on {forum}.
+
+      If this was you, click the following link to reset your password:
+      {url}
+
+      If you do not wish to change your password, just ignore this email and nothing will happen.
+
+##
+# REUSED TRANSLATIONS - These keys should not be used directly in code!
+##
+
+# Translations in this namespace are referenced by two or more unique keys.
+ref:
+  all_discussions: All Discussions
+  change_email: Change Email
+  change_password: Change Password
+  confirm_password: Confirm Password
+  confirmation_email_sent: "We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
+  delete: Delete
+  delete_forever: Delete Forever
+  discussions: Discussions
+  edit: Edit
+  email: Email
+  load_more: Load More
+  log_in: Log In
+  log_out: Log Out
+  mark_all_as_read: Mark All as Read
+  next_page: Next Page
+  notifications: Notifications
+  okay: OK                                     # Referenced by flarum-tags.yml
+  password: Password
+  reply: Reply                                 # Referenced by flarum-mentions.yml
+  reset_your_password: Reset Your Password
+  restore: Restore
+  save_changes: Save Changes                   # Referenced by flarum-suspend.yml, flarum-tags.yml
+  settings: Settings
+  sign_up: Sign Up
+  some_others: "{count} other|{count} others"  # Referenced by flarum-likes.yml, flarum-mentions.yml
+  start_a_discussion: Start a Discussion
+  username: Username
+  write_a_reply: Write a Reply...
+  you: You                                     # Referenced by flarum-likes.yml, flarum-mentions.yml
+
+##
+# GROUP NAMES - These keys are translated at the back end.
+##
+
+# Translations in this namespace are used to translate default group names.
+groups:
+  admin: Admin
+  admins: Admins
+  guest: Guest
+  guests: Guests
+  member: Member
+  members: Members
+  mod: Mod
+  mods: Mods

--- a/locale/flarum/flags.yml
+++ b/locale/flarum/flags.yml
@@ -1,61 +1,59 @@
-flarum-flags:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Permissions page of the admin interface.
+  permissions:
+    flag_posts_label: Flag posts
+    view_flags_label: View flagged posts
 
-    # These translations are used in the Permissions page of the admin interface.
-    permissions:
-      flag_posts_label: Flag posts
-      view_flags_label: View flagged posts
+  # These translations are used in the Flags Settings modal dialog.
+  settings:
+    guidelines_url_label: Community Guidelines URL
+    title: Flags Settings
 
-    # These translations are used in the Flags Settings modal dialog.
-    settings:
-      guidelines_url_label: Community Guidelines URL
-      title: Flags Settings
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are used by the Flag Post modal dialog.
+  flag_post:
+    confirmation_message: Thank you for flagging this post. Our moderators will look into it.
+    dismiss_button: => ref.okay
+    reason_inappropriate_label: Inappropriate
+    reason_inappropriate_text: "This post is offensive, abusive, or violates our <a>community guidelines</a>."
+    reason_off_topic_label: "Off-topic"
+    reason_off_topic_text: This post is not relevant to the current discussion and should be moved elsewhere.
+    reason_other_label: Other
+    reason_spam_label: Spam
+    reason_spam_text: This post is an advertisement.
+    submit_button: => flags::ref.flag_post
+    title: => flags::ref.flag_post
 
-    # These translations are used by the Flag Post modal dialog.
-    flag_post:
-      confirmation_message: Thank you for flagging this post. Our moderators will look into it.
-      dismiss_button: => core.ref.okay
-      reason_inappropriate_label: Inappropriate
-      reason_inappropriate_text: "This post is offensive, abusive, or violates our <a>community guidelines</a>."
-      reason_off_topic_label: "Off-topic"
-      reason_off_topic_text: This post is not relevant to the current discussion and should be moved elsewhere.
-      reason_other_label: Other
-      reason_spam_label: Spam
-      reason_spam_text: This post is an advertisement.
-      submit_button: => flarum-flags.ref.flag_post
-      title: => flarum-flags.ref.flag_post
+  # These translations are used by the Flagged Posts dropdown, a.k.a. "the flag".
+  flagged_posts:
+    empty_text: No Flags
+    item_text: "{username} in <em>{discussion}</em>"
+    title: => flags::ref.flagged_posts
+    tooltip: => flags::ref.flagged_posts
 
-    # These translations are used by the Flagged Posts dropdown, a.k.a. "the flag".
-    flagged_posts:
-      empty_text: No Flags
-      item_text: "{username} in <em>{discussion}</em>"
-      title: => flarum-flags.ref.flagged_posts
-      tooltip: => flarum-flags.ref.flagged_posts
+  # These translations are used by the frame displayed around flagged posts.
+  post:
+    dismiss_flag_button: Dismiss Flag
+    flagged_by_text: "{username} flagged"
+    flagged_by_with_reason_text: "{username} flagged as {reason}"
 
-    # These translations are used by the frame displayed around flagged posts.
-    post:
-      dismiss_flag_button: Dismiss Flag
-      flagged_by_text: "{username} flagged"
-      flagged_by_with_reason_text: "{username} flagged as {reason}"
+  # These translations are used by the post control buttons.
+  post_controls:
+    flag_button: Flag
 
-    # These translations are used by the post control buttons.
-    post_controls:
-      flag_button: Flag
+##
+# REUSED TRANSLATIONS - These keys should not be used directly in code!
+##
 
-  ##
-  # REUSED TRANSLATIONS - These keys should not be used directly in code!
-  ##
-
-  # Translations in this namespace are referenced by two or more unique keys.
-  ref:
-    flag_post: Flag Post
-    flagged_posts: Flagged Posts
+# Translations in this namespace are referenced by two or more unique keys.
+ref:
+  flag_post: Flag Post
+  flagged_posts: Flagged Posts

--- a/locale/flarum/likes.yml
+++ b/locale/flarum/likes.yml
@@ -1,37 +1,35 @@
-flarum-likes:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Permissions page of the admin interface.
+  permissions:
+    like_posts_label: Like posts
 
-    # These translations are used in the Permissions page of the admin interface.
-    permissions:
-      like_posts_label: Like posts
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are used by the Notifications dropdown, a.k.a. "the bell".
+  notifications:
+    others_text: => ref.some_others
+    post_liked_text: "{username} liked your post"  # Can be pluralized to agree with the number of users!
 
-    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
-    notifications:
-      others_text: => core.ref.some_others
-      post_liked_text: "{username} liked your post"  # Can be pluralized to agree with the number of users!
+  # These translations are displayed beneath individual posts.
+  post:
+    like_link: Like
+    liked_by_self_text: "{users} like this."  # Can be pluralized to agree with the number of users!
+    liked_by_text: "{users} likes this.|{users} like this."
+    others_link: => ref.some_others
+    unlike_link: Unlike
+    you_text: => ref.you
 
-    # These translations are displayed beneath individual posts.
-    post:
-      like_link: Like
-      liked_by_self_text: "{users} like this."  # Can be pluralized to agree with the number of users!
-      liked_by_text: "{users} likes this.|{users} like this."
-      others_link: => core.ref.some_others
-      unlike_link: Unlike
-      you_text: => core.ref.you
+  # These translations are used by the Users Who Like This modal dialog.
+  post_likes:
+    title: Users Who Like This
 
-    # These translations are used by the Users Who Like This modal dialog.
-    post_likes:
-      title: Users Who Like This
-
-    # These translations are used in the Settings page.
-    settings:
-      notify_post_liked_label: Someone likes one of my posts
+  # These translations are used in the Settings page.
+  settings:
+    notify_post_liked_label: Someone likes one of my posts

--- a/locale/flarum/lock.yml
+++ b/locale/flarum/lock.yml
@@ -1,37 +1,35 @@
-flarum-lock:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Permissions page of the admin interface.
+  permissions:
+    lock_discussions_label: Lock discussions
 
-    # These translations are used in the Permissions page of the admin interface.
-    permissions:
-      lock_discussions_label: Lock discussions
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are displayed as tooltips for discussion badges.
+  badge:
+    locked_tooltip: Locked
 
-    # These translations are displayed as tooltips for discussion badges.
-    badge:
-      locked_tooltip: Locked
+  # These translations are used by the discussion control buttons.
+  discussion_controls:
+    lock_button: Lock
+    unlock_button: Unlock
 
-    # These translations are used by the discussion control buttons.
-    discussion_controls:
-      lock_button: Lock
-      unlock_button: Unlock
+  # These translations are used by the Notifications dropdown, a.k.a. "the bell".
+  notifications:
+    discussion_locked_text: "{username} locked"
 
-    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
-    notifications:
-      discussion_locked_text: "{username} locked"
+  # These translations are displayed between posts in the post stream.
+  post_stream:
+    discussion_locked_text: "{username} locked the discussion."
+    discussion_unlocked_text: "{username} unlocked the discussion."
 
-    # These translations are displayed between posts in the post stream.
-    post_stream:
-      discussion_locked_text: "{username} locked the discussion."
-      discussion_unlocked_text: "{username} unlocked the discussion."
-
-    # These translations are used in the Settings page.
-    settings:
-      notify_discussion_locked_label: Someone locks a discussion I started
+  # These translations are used in the Settings page.
+  settings:
+    notify_discussion_locked_label: Someone locks a discussion I started

--- a/locale/flarum/mentions.yml
+++ b/locale/flarum/mentions.yml
@@ -1,36 +1,34 @@
-flarum-mentions:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are used by the composer (reply autocompletion function).
+  composer:
+    reply_to_post_text: "Reply to #{number}"
 
-    # These translations are used by the composer (reply autocompletion function).
-    composer:
-      reply_to_post_text: "Reply to #{number}"
+  # These translations are used by the Notifications dropdown, a.k.a. "the bell".
+  notifications:
+    others_text: => ref.some_others
+    post_mentioned_text: "{username} replied to your post"  # Can be pluralized to agree with the number of users!
+    user_mentioned_text: "{username} mentioned you"
 
-    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
-    notifications:
-      others_text: => core.ref.some_others
-      post_mentioned_text: "{username} replied to your post"  # Can be pluralized to agree with the number of users!
-      user_mentioned_text: "{username} mentioned you"
+  # These translations are displayed beneath individual posts.
+  post:
+    mentioned_by_self_text: "{users} replied to this."  # Can be pluralized to agree with the number of users!
+    mentioned_by_text: "{users} replied to this."       # Can be pluralized to agree with the number of users!
+    others_text: => ref.some_others
+    quote_button: Quote
+    reply_link: => ref.reply
+    you_text: => ref.you
 
-    # These translations are displayed beneath individual posts.
-    post:
-      mentioned_by_self_text: "{users} replied to this."  # Can be pluralized to agree with the number of users!
-      mentioned_by_text: "{users} replied to this."       # Can be pluralized to agree with the number of users!
-      others_text: => core.ref.some_others
-      quote_button: Quote
-      reply_link: => core.ref.reply
-      you_text: => core.ref.you
+  # These translations are used in the Settings page.
+  settings:
+    notify_post_mentioned_label: Someone replies to one of my posts
+    notify_user_mentioned_label: Someone mentions me in a post
 
-    # These translations are used in the Settings page.
-    settings:
-      notify_post_mentioned_label: Someone replies to one of my posts
-      notify_user_mentioned_label: Someone mentions me in a post
-
-    # These translations are used in the user profile page and profile popup.
-    user:
-      mentions_link: Mentions
+  # These translations are used in the user profile page and profile popup.
+  user:
+    mentions_link: Mentions

--- a/locale/flarum/pusher.yml
+++ b/locale/flarum/pusher.yml
@@ -1,23 +1,21 @@
-flarum-pusher:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Pusher Settings modal dialog.
+  pusher_settings:
+    app_cluster_label: Cluster
+    app_id_label: App ID
+    app_key_label: App Key
+    app_secret_label: App Secret
+    title: Pusher Settings
 
-    # These translations are used in the Pusher Settings modal dialog.
-    pusher_settings:
-      app_cluster_label: Cluster
-      app_id_label: App ID
-      app_key_label: App Key
-      app_secret_label: App Secret
-      title: Pusher Settings
+# Translations in this namespace are used by the admin interface.
+forum:
 
-  # Translations in this namespace are used by the admin interface.
-  forum:
-
-    # These translations are used in the discussion list.
-    discussion_list:
-      show_updates_text: "Show {count} updated discussion|Show {count} updated discussions"
+  # These translations are used in the discussion list.
+  discussion_list:
+    show_updates_text: "Show {count} updated discussion|Show {count} updated discussions"

--- a/locale/flarum/sticky.yml
+++ b/locale/flarum/sticky.yml
@@ -1,37 +1,35 @@
-flarum-sticky:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Permissions page of the admin interface.
+  permissions:
+    sticky_discussions_label: Sticky discussions
 
-    # These translations are used in the Permissions page of the admin interface.
-    permissions:
-      sticky_discussions_label: Sticky discussions
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are displayed as tooltips for discussion badges.
+  badge:
+    sticky_tooltip: => sticky::ref.sticky
 
-    # These translations are displayed as tooltips for discussion badges.
-    badge:
-      sticky_tooltip: => flarum-sticky.ref.sticky
+  # These translations are used by the discussion control buttons.
+  discussion_controls:
+    sticky_button: => sticky::ref.sticky
+    unsticky_button: Unsticky
 
-    # These translations are used by the discussion control buttons.
-    discussion_controls:
-      sticky_button: => flarum-sticky.ref.sticky
-      unsticky_button: Unsticky
+  # These translations are displayed between posts in the post stream.
+  post_stream:
+    discussion_stickied_text: "{username} stickied the discussion."
+    discussion_unstickied_text: "{username} unstickied the discussion."
 
-    # These translations are displayed between posts in the post stream.
-    post_stream:
-      discussion_stickied_text: "{username} stickied the discussion."
-      discussion_unstickied_text: "{username} unstickied the discussion."
+##
+# REUSED TRANSLATIONS - These keys should not be used directly in code!
+##
 
-  ##
-  # REUSED TRANSLATIONS - These keys should not be used directly in code!
-  ##
-
-  # Translations in this namespace are referenced by two or more unique keys.
-  ref:
-    sticky: Sticky
+# Translations in this namespace are referenced by two or more unique keys.
+ref:
+  sticky: Sticky

--- a/locale/flarum/subscriptions.yml
+++ b/locale/flarum/subscriptions.yml
@@ -1,54 +1,52 @@
-flarum-subscriptions:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are displayed as tooltips for discussion badges.
+  badge:
+    following_tooltip: => subscriptions::ref.following
+    ignoring_tooltip: => subscriptions::ref.ignoring
 
-    # These translations are displayed as tooltips for discussion badges.
-    badge:
-      following_tooltip: => flarum-subscriptions.ref.following
-      ignoring_tooltip: => flarum-subscriptions.ref.ignoring
+  # These translations are used by the discussion control buttons.
+  discussion_controls:
+    follow_button: => subscriptions::ref.follow
+    unfollow_button: Unfollow
+    unignore_button: Unignore
 
-    # These translations are used by the discussion control buttons.
-    discussion_controls:
-      follow_button: => flarum-subscriptions.ref.follow
-      unfollow_button: Unfollow
-      unignore_button: Unignore
+  # These translations are used on the index page, peripheral to the discussion list.
+  index:
+    following_link: => subscriptions::ref.following
 
-    # These translations are used on the index page, peripheral to the discussion list.
-    index:
-      following_link: => flarum-subscriptions.ref.following
+  # These translations are used by the Notifications dropdown, a.k.a. "the bell".
+  notifications:
+    new_post_text: "{username} posted"
 
-    # These translations are used by the Notifications dropdown, a.k.a. "the bell".
-    notifications:
-      new_post_text: "{username} posted"
+  # These translations are used in the Settings page.
+  settings:
+    follow_after_reply_label: Automatically follow discussions that I reply to
+    notify_new_post_label: Someone posts in a discussion I'm following
 
-    # These translations are used in the Settings page.
-    settings:
-      follow_after_reply_label: Automatically follow discussions that I reply to
-      notify_new_post_label: Someone posts in a discussion I'm following
+  # These translations are used in the subscription menu displayed to the right of the post stream.
+  sub_controls:
+    follow_button: => subscriptions::ref.follow
+    following_button: => subscriptions::ref.following
+    following_text: Be notified of all replies.
+    ignoring_button: => subscriptions::ref.ignoring
+    ignoring_text: Never be notified. Hide from the discussion list.
+    not_following_button: Not Following
+    not_following_text: "Be notified only when @mentioned."
+    notify_alert_tooltip: Get a forum notification when there are new posts
+    notify_email_tooltip: Get an email when there are new posts
 
-    # These translations are used in the subscription menu displayed to the right of the post stream.
-    sub_controls:
-      follow_button: => flarum-subscriptions.ref.follow
-      following_button: => flarum-subscriptions.ref.following
-      following_text: Be notified of all replies.
-      ignoring_button: => flarum-subscriptions.ref.ignoring
-      ignoring_text: Never be notified. Hide from the discussion list.
-      not_following_button: Not Following
-      not_following_text: "Be notified only when @mentioned."
-      notify_alert_tooltip: Get a forum notification when there are new posts
-      notify_email_tooltip: Get an email when there are new posts
+##
+# REUSED TRANSLATIONS - These keys should not be used directly in code!
+##
 
-  ##
-  # REUSED TRANSLATIONS - These keys should not be used directly in code!
-  ##
-
-  # Translations in this namespace are referenced by two or more unique keys.
-  ref:
-    follow: Follow
-    following: Following
-    ignoring: Ignoring
+# Translations in this namespace are referenced by two or more unique keys.
+ref:
+  follow: Follow
+  following: Following
+  ignoring: Ignoring

--- a/locale/flarum/suspend.yml
+++ b/locale/flarum/suspend.yml
@@ -1,33 +1,31 @@
-flarum-suspend:
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
 
-  ##
-  # UNIQUE KEYS - The following keys are used in only one location each.
-  ##
+# Translations in this namespace are used by the admin interface.
+admin:
 
-  # Translations in this namespace are used by the admin interface.
-  admin:
+  # These translations are used in the Permissions page of the admin interface.
+  permissions:
+    suspend_users_label: Suspend users
 
-    # These translations are used in the Permissions page of the admin interface.
-    permissions:
-      suspend_users_label: Suspend users
+# Translations in this namespace are used by the forum user interface.
+forum:
 
-  # Translations in this namespace are used by the forum user interface.
-  forum:
+  # These translations are used in the Suspend User modal dialog (admin function).
+  suspend_user:
+    indefinitely_label: Suspended indefinitely
+    limited_time_label: Suspended for a limited time...
+    limited_time_days_text: " days"
+    not_suspended_label: Not suspended
+    status_heading: Suspension Status
+    submit_button: => ref.save_changes
+    title: "Suspend {username}"
 
-    # These translations are used in the Suspend User modal dialog (admin function).
-    suspend_user:
-      indefinitely_label: Suspended indefinitely
-      limited_time_label: Suspended for a limited time...
-      limited_time_days_text: " days"
-      not_suspended_label: Not suspended
-      status_heading: Suspension Status
-      submit_button: => core.ref.save_changes
-      title: "Suspend {username}"
+  # These translations are displayed as tooltips for user badges.
+  user_badge:
+    suspended_tooltip: Suspended
 
-    # These translations are displayed as tooltips for user badges.
-    user_badge:
-      suspended_tooltip: Suspended
-
-    # These translations are found on the user profile page (admin function).
-    user_controls:
-      suspend_button: Suspend
+  # These translations are found on the user profile page (admin function).
+  user_controls:
+    suspend_button: Suspend


### PR DESCRIPTION
- Removes existing first-level prefix and de-dents files.
- Adjusts key references to use new namespacing.
- Pluralizes the `group` scope prefix in `core.yml`.
- Adjusts one reference in `core.yml` to match.