### PR TITLE
Add "Rename" to the reused translations

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -224,7 +224,7 @@ core:
       delete_confirmation: "Are you sure you want to delete this discussion?"
       delete_forever_button: => core.ref.delete_forever
       log_in_to_reply_button: Log In to Reply
-      rename_button: Rename
+      rename_button: => core.ref.rename
       reply_button: => core.ref.reply
       restore_button: => core.ref.restore
 
@@ -337,7 +337,7 @@ core:
     # These translations are used by the rename discussion modal.
     rename_discussion:
       title: Enter a new title for this discussion
-      submit_button: Rename
+      submit_button: => core.ref.rename
 
     # These translations are used by the search results dropdown list.
     search:
@@ -521,6 +521,7 @@ core:
     notifications: Notifications
     okay: OK                                     # Referenced by flarum-tags.yml
     password: Password
+    rename: Rename
     reply: Reply                                 # Referenced by flarum-mentions.yml
     reset_your_password: Reset Your Password
     restore: Restore


### PR DESCRIPTION
Just because there are now two references of it.