### PR TITLE
flagged_by text grammar fix

### DIFF
--- a/locale/flarum-flags.yml
+++ b/locale/flarum-flags.yml
@@ -45,7 +45,7 @@ flarum-flags:
     post:
       dismiss_flag_button: Dismiss Flag
       flagged_by_text: "Flagged by {username}"
-      flagged_by_with_reason_text: "{username} flagged this as {reason}"
+      flagged_by_with_reason_text: "Flagged by {username} as {reason}"
 
     # These translations are used by the post control buttons.
     post_controls:

--- a/locale/flarum-flags.yml
+++ b/locale/flarum-flags.yml
@@ -44,8 +44,8 @@ flarum-flags:
     # These translations are used by the frame displayed around flagged posts.
     post:
       dismiss_flag_button: Dismiss Flag
-      flagged_by_text: "{username} flagged"
-      flagged_by_with_reason_text: "{username} flagged as {reason}"
+      flagged_by_text: "Flagged by {username}"
+      flagged_by_with_reason_text: "{username} flagged this as {reason}"
 
     # These translations are used by the post control buttons.
     post_controls:


### PR DESCRIPTION
Changed "{username} flagged" to "Flagged by {username}" and  
"{username} flagged as {reason}" to "{username} flagged this as {reason}"