### PR TITLE
Remove unnecessary double quotes

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -20,7 +20,7 @@ core:
       colors_heading: Colors
       colors_text: "Choose two colors to theme your forum with. The first will be used as a highlight color, while the second will be used to style background elements."
       custom_footer_heading: Custom Footer
-      custom_footer_text: "Add HTML to be displayed at the very bottom of the page."
+      custom_footer_text: Add HTML to be displayed at the very bottom of the page.
       custom_header_heading: Custom Header
       custom_header_text: "Add HTML to be displayed at the very top of the page, above Flarum's own header."
       custom_styles_heading: Custom Styles
@@ -63,7 +63,7 @@ core:
 
     # These translations are used in the Edit Custom Footer modal dialog.
     edit_footer:
-      customize_text: "Add HTML to be displayed at the very bottom of the page."
+      customize_text: Add HTML to be displayed at the very bottom of the page.
       submit_button: => core.ref.save_changes
       title: Edit Custom Footer
 


### PR DESCRIPTION
Double quotes are only necessary when some characters are present (please see [this documentation](https://symfony.com/doc/3.4/components/yaml/yaml_format.html#strings)).