### PR TITLE
[WIP] sort keys

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -133,8 +133,8 @@ core:
 
     # These translations are used in the Permissions page of the admin interface.
     permissions:
-      allow_renaming_label: Allow renaming
       allow_post_editing_label: Allow post editing
+      allow_renaming_label: Allow renaming
       create_heading: Create
       delete_discussions_forever_label: Delete discussions forever
       delete_discussions_label: Delete discussions
@@ -178,8 +178,8 @@ core:
 
     # These translations are used in the Change Email modal dialog.
     change_email:
-      confirmation_message: => core.ref.confirmation_email_sent
       confirm_password_placeholder: => core.ref.confirm_password
+      confirmation_message: => core.ref.confirmation_email_sent
       dismiss_button: => core.ref.okay
       incorrect_password_message: The password you entered is incorrect.
       submit_button: => core.ref.save_changes
@@ -342,8 +342,8 @@ core:
 
     # These translations are used by the rename discussion modal.
     rename_discussion:
-      title: Rename Discussion
       submit_button: => core.ref.rename
+      title: Rename Discussion
 
     # These translations are used by the search results dropdown list.
     search:
@@ -366,8 +366,8 @@ core:
 
     # These translations are used in the Sign Up modal dialog.
     sign_up:
-      email_placeholder: => core.ref.email
       dismiss_button: => core.ref.okay
+      email_placeholder: => core.ref.email
       log_in_text: "Already have an account? <a>Log In</a>"
       password_placeholder: => core.ref.password
       submit_button: => core.ref.sign_up
@@ -384,8 +384,8 @@ core:
       in_discussion_text: "In {discussion}"
       joined_date_text: "Joined {ago}"
       online_text: Online
-      posts_load_more_button: => core.ref.load_more
       posts_link: => core.ref.posts
+      posts_load_more_button: => core.ref.load_more
       settings_link: => core.ref.settings
 
     # These translations are found on the user profile page (admin function).
@@ -408,10 +408,6 @@ core:
     badge:
       hidden_tooltip: Hidden
 
-    # These translations are used to modify usernames.
-    username:
-      deleted_text: "[deleted]"
-
     # These translations are displayed as error messages.
     error:
       generic_message: "Oops! Something went wrong. Please reload the page and try again."
@@ -429,6 +425,10 @@ core:
       glue_text: ", "
       three_text: "{first}, {second}, and {third}"
       two_text: "{first} and {second}"
+
+    # These translations are used to modify usernames.
+    username:
+      deleted_text: "[deleted]"
 
   # Translations in this namespace are used in views other than Flarum's normal JS client.
   views:
@@ -480,7 +480,6 @@ core:
 
     # These translations are used in emails sent when users register new accounts.
     activate_account:
-      subject: Activate Your New Account
       body: |
         Hey {username}!
 
@@ -490,10 +489,10 @@ core:
         {url}
 
         If you did not sign up, please ignore this email.
+      subject: Activate Your New Account
 
     # These translations are used in emails sent when users change their email address.
     confirm_email:
-      subject: Confirm Your New Email Address
       body: |
         Hey {username}!
 
@@ -503,10 +502,10 @@ core:
         {url}
 
         If this was not you, please ignore this email.
+      subject: Confirm Your New Email Address
 
     # These translations are used in emails sent when users ask to reset their passwords.
     reset_password:
-      subject: => core.ref.reset_your_password
       body: |
         Hey {username}!
 
@@ -516,6 +515,7 @@ core:
         {url}
 
         If you do not wish to change your password, just ignore this email and nothing will happen.
+      subject: => core.ref.reset_your_password
 
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!
@@ -547,8 +547,8 @@ core:
     okay: OK                                     # Referenced by flarum-tags.yml
     password: Password
     posts: Posts                                 # Referenced by flarum-statistics.yml
-    remove: Remove
     previous_page: Previous Page
+    remove: Remove
     rename: Rename
     reply: Reply                                 # Referenced by flarum-mentions.yml
     reset_your_password: Reset Your Password

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -480,6 +480,7 @@ core:
 
     # These translations are used in emails sent when users register new accounts.
     activate_account:
+      subject: Activate Your New Account
       body: |
         Hey {username}!
 
@@ -489,10 +490,10 @@ core:
         {url}
 
         If you did not sign up, please ignore this email.
-      subject: Activate Your New Account
 
     # These translations are used in emails sent when users change their email address.
     confirm_email:
+      subject: Confirm Your New Email Address
       body: |
         Hey {username}!
 
@@ -502,10 +503,10 @@ core:
         {url}
 
         If this was not you, please ignore this email.
-      subject: Confirm Your New Email Address
 
     # These translations are used in emails sent when users ask to reset their passwords.
     reset_password:
+      subject: => core.ref.reset_your_password
       body: |
         Hey {username}!
 
@@ -515,7 +516,6 @@ core:
         {url}
 
         If you do not wish to change your password, just ignore this email and nothing will happen.
-      subject: => core.ref.reset_your_password
 
   ##
   # REUSED TRANSLATIONS - These keys should not be used directly in code!

--- a/locale/flarum-suspend.yml
+++ b/locale/flarum-suspend.yml
@@ -17,8 +17,8 @@ flarum-suspend:
     # These translations are used in the Suspend User modal dialog (admin function).
     suspend_user:
       indefinitely_label: Suspended indefinitely
-      limited_time_label: Suspended for a limited time...
       limited_time_days_text: " days"
+      limited_time_label: Suspended for a limited time...
       not_suspended_label: Not suspended
       status_heading: Suspension Status
       submit_button: => core.ref.save_changes

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -82,8 +82,8 @@ flarum-tags:
 
     # These translations are displayed between posts in the post stream.
     post_stream:
-      added_tags_text: "{username} added the {tagsAdded}."
       added_and_removed_tags_text: "{username} added the {tagsAdded} and removed the {tagsRemoved}."
+      added_tags_text: "{username} added the {tagsAdded}."
       removed_tags_text: "{username} removed the {tagsRemoved}."
       tags_text: "{tags} tag|{tags} tags"
 


### PR DESCRIPTION
on second thought, don't you think keys with multiple lines value (e.g `core.email.activate_account.body`) should have more weight, and be sorted alphabetically after non-multiple line values?